### PR TITLE
Fix exception handling

### DIFF
--- a/vio/vio/pub/vim/drivers/openstacksdk/sdk.py
+++ b/vio/vio/pub/vim/drivers/openstacksdk/sdk.py
@@ -39,7 +39,7 @@ def parse_exception(ex):
             code = ex.http_status
         message = ex.message
         data = {}
-        if ex.details is None:
+        if ex.details is None and ex.response is not None:
             data = ex.response.json()
         else:
             try:


### PR DESCRIPTION
If ex.response is None, the error message will looks like:
AttributeError: 'NoneType' object has no attribute 'json'