### PR TITLE
Always display network.vlan_transparent to false

### DIFF
--- a/vio/vio/pub/vim/vimapi/network/OperateNetwork.py
+++ b/vio/vio/pub/vim/vimapi/network/OperateNetwork.py
@@ -77,7 +77,7 @@ class OperateNetwork(BaseNet):
         result['segmentationId'] = network.provider_segmentation_id
         result['networkType'] = network.provider_network_type
         result['physicalNetwork'] = network.provider_physical_network
-        result['vlanTransparent'] = True
+        result['vlanTransparent'] = False
         result['shared'] = network.is_shared
         result['routerExternal'] = network.is_router_external
         return result


### PR DESCRIPTION
Since VIO 3.1 didn't support network.vlan_transparent,
set this attribute default to false when do network show.